### PR TITLE
Enable pasting clipboard images into notes

### DIFF
--- a/ui/card.js
+++ b/ui/card.js
@@ -1,6 +1,7 @@
 import { nowIso, createElement, autoResize } from "../utils.js";
 import { GravityStore } from "../store.js";
 import { ClassifierClient } from "../classifier.js";
+import { enableClipboardImagePaste } from "./imagePaste.js";
 
 let currentEditingCard = null;
 let mergeInProgress = false;
@@ -30,6 +31,8 @@ export function renderCard(record, { notesContainer }) {
     editor.value  = record.markdownText;
     editor.setAttribute("rows", "1");
     autoResize(editor);
+
+    enableClipboardImagePaste(editor);
 
     // Live preview
     editor.addEventListener("input", () => {

--- a/ui/card.js
+++ b/ui/card.js
@@ -1,7 +1,7 @@
 import { nowIso, createElement, autoResize } from "../utils.js";
 import { GravityStore } from "../store.js";
 import { ClassifierClient } from "../classifier.js";
-import { enableClipboardImagePaste } from "./imagePaste.js";
+import { enableClipboardImagePaste, waitForPendingImagePastes } from "./imagePaste.js";
 
 let currentEditingCard = null;
 let mergeInProgress = false;
@@ -122,12 +122,13 @@ function enableInPlaceEditing(card, notesContainer) {
     updateActionButtons(notesContainer);
 }
 
-function finalizeCard(card, notesContainer) {
+async function finalizeCard(card, notesContainer) {
     if (!card || (currentEditingCard && currentEditingCard !== card) || mergeInProgress) return;
     if (!card.classList.contains("editing-in-place")) return;
 
     const editor  = card.querySelector(".markdown-editor");
     const preview = card.querySelector(".markdown-content");
+    await waitForPendingImagePastes(editor);
     const text    = editor.value;
     const trimmed = text.trim();
     const was     = card.dataset.initialValue ?? text;

--- a/ui/imagePaste.js
+++ b/ui/imagePaste.js
@@ -1,0 +1,101 @@
+const PASTED_IMAGE_ALT_TEXT_PREFIX = "Pasted image";
+const DOUBLE_LINE_BREAK = "\n\n";
+const IMAGE_READ_ERROR_MESSAGE = "Failed to read pasted image";
+
+/**
+ * Convert a File into a data URL so it can be embedded in Markdown.
+ * @param {File} file
+ * @returns {Promise<string>}
+ */
+function readFileAsDataUrl(file) {
+    return new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.addEventListener("load", () => resolve(typeof reader.result === "string" ? reader.result : ""));
+        reader.addEventListener("error", () => reject(new Error(IMAGE_READ_ERROR_MESSAGE)));
+        reader.readAsDataURL(file);
+    });
+}
+
+/**
+ * Build a Markdown image snippet that references the provided data URL.
+ * @param {string} dataUrl
+ * @returns {string}
+ */
+function buildMarkdownForImage(dataUrl) {
+    const timestamp = new Date().toISOString();
+    const safeAltText = `${PASTED_IMAGE_ALT_TEXT_PREFIX} ${timestamp}`.replace(/[\[\]]/g, "");
+    return `![${safeAltText}](${dataUrl})`;
+}
+
+/**
+ * Insert Markdown text at the current caret location, ensuring blank lines around it.
+ * @param {HTMLTextAreaElement} textarea
+ * @param {string} insertionText
+ */
+function insertMarkdownAtCaret(textarea, insertionText) {
+    const selectionStart = textarea.selectionStart ?? textarea.value.length;
+    const selectionEnd = textarea.selectionEnd ?? selectionStart;
+
+    const textBeforeSelection = textarea.value.slice(0, selectionStart);
+    const textAfterSelection = textarea.value.slice(selectionEnd);
+
+    const needsPrefixBreak = textBeforeSelection.length > 0 && !textBeforeSelection.endsWith("\n") && !textBeforeSelection.endsWith(DOUBLE_LINE_BREAK);
+    const prefixBreak = needsPrefixBreak ? DOUBLE_LINE_BREAK : "";
+
+    let suffixBreak = DOUBLE_LINE_BREAK;
+    if (textAfterSelection.startsWith(DOUBLE_LINE_BREAK)) suffixBreak = "";
+    else if (textAfterSelection.startsWith("\n")) suffixBreak = "\n";
+
+    const finalInsertion = `${prefixBreak}${insertionText}${suffixBreak}`;
+
+    const nextValue = `${textBeforeSelection}${finalInsertion}${textAfterSelection}`;
+    textarea.value = nextValue;
+
+    const caretPosition = textBeforeSelection.length + finalInsertion.length;
+    textarea.setSelectionRange(caretPosition, caretPosition);
+}
+
+/**
+ * Sequentially read image files and insert them into the textarea.
+ * @param {HTMLTextAreaElement} textarea
+ * @param {File[]} files
+ */
+async function handleClipboardImages(textarea, files) {
+    for (const file of files) {
+        try {
+            const dataUrl = await readFileAsDataUrl(file);
+            if (!dataUrl) continue;
+            const markdown = buildMarkdownForImage(dataUrl);
+            insertMarkdownAtCaret(textarea, markdown);
+        } catch (error) {
+            console.error(error);
+        }
+    }
+    textarea.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+/**
+ * Attach clipboard listeners so that pasted images become Markdown image links.
+ * @param {HTMLTextAreaElement} textarea
+ */
+export function enableClipboardImagePaste(textarea) {
+    if (!textarea) return;
+    textarea.addEventListener("paste", (event) => {
+        const clipboardData = event.clipboardData;
+        if (!clipboardData || !clipboardData.items) return;
+
+        const imageFiles = Array.from(clipboardData.items)
+            .filter((item) => typeof item.type === "string" && item.type.startsWith("image/"))
+            .map((item) => item.getAsFile())
+            .filter((file) => {
+                if (!file) return false;
+                if (typeof File === "function") return file instanceof File;
+                return true;
+            });
+
+        if (imageFiles.length === 0) return;
+
+        event.preventDefault();
+        handleClipboardImages(textarea, imageFiles);
+    });
+}

--- a/ui/topEditor.js
+++ b/ui/topEditor.js
@@ -1,7 +1,7 @@
 import { nowIso, generateNoteId, createElement, autoResize } from "../utils.js";
 import { GravityStore } from "../store.js";
 import { triggerClassificationForCard } from "./card.js";
-import { enableClipboardImagePaste } from "./imagePaste.js";
+import { enableClipboardImagePaste, waitForPendingImagePastes } from "./imagePaste.js";
 
 /**
  * Mount the always-empty top editor. It never persists empties; on finalize
@@ -74,7 +74,8 @@ export function mountTopEditor({ notesContainer, onCreateRecord }) {
 
     keepFocus(editor);
 
-    function finalizeTopEditor() {
+    async function finalizeTopEditor() {
+        await waitForPendingImagePastes(editor);
         const text = editor.value;
         const trimmed = text.trim();
 

--- a/ui/topEditor.js
+++ b/ui/topEditor.js
@@ -1,6 +1,7 @@
 import { nowIso, generateNoteId, createElement, autoResize } from "../utils.js";
 import { GravityStore } from "../store.js";
 import { triggerClassificationForCard } from "./card.js";
+import { enableClipboardImagePaste } from "./imagePaste.js";
 
 /**
  * Mount the always-empty top editor. It never persists empties; on finalize
@@ -36,6 +37,8 @@ export function mountTopEditor({ notesContainer, onCreateRecord }) {
 
     // Finalize on blur
     editor.addEventListener("blur", finalizeTopEditor);
+
+    enableClipboardImagePaste(editor);
 
     wrapper.append(preview, editor);
     host.appendChild(wrapper);


### PR DESCRIPTION
## Summary
- add a clipboard helper that converts pasted images into Markdown data URLs
- enable the top editor and card editors to accept image pastes and update previews automatically

## Testing
- not run (no automated tests provided)


------
https://chatgpt.com/codex/tasks/task_e_68d4654702988327908490f8b7f4017d