### PR TITLE
Use image placeholders in editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ ones.
       passive notes except the bottom one).
     * Merge the *bottom-most* note *up* into the active (top) note using the `Merge ↑` button (only available on the
       bottom note when there are at least two notes).
-* **Image Pasting:** Paste images directly from your clipboard into the editor. They are converted to base64 data URLs
-  and embedded in the Markdown.
+* **Image Pasting:** Paste images directly from your clipboard into the editor. Notes keep readable placeholders such as
+  `![[pasted-image-*.png]]` while the rendered preview displays the actual image data.
 * **Auto-Resizing Editor:** The text area automatically adjusts its height to fit the content as you type.
 * **Session-Based:** Notes exist only within the current browser session. Reloading the page will clear all notes.
 

--- a/store.js
+++ b/store.js
@@ -1,5 +1,6 @@
 import { appConfig } from "./config.js";
 import { nowIso } from "./utils.js";
+import { collectReferencedAttachments, sanitizeAttachmentDictionary } from "./ui/imagePaste.js";
 
 /**
  * @typedef {Object} NoteRecord
@@ -9,6 +10,7 @@ import { nowIso } from "./utils.js";
  * @property {string} updatedAtIso
  * @property {string} lastActivityIso
  * @property {object=} classification
+ * @property {Record<string, { dataUrl: string, altText: string }>=} attachments
  */
 
 export const GravityStore = (() => {
@@ -17,14 +19,16 @@ export const GravityStore = (() => {
         if (!raw) return [];
         try {
             const arr = JSON.parse(raw);
-            return Array.isArray(arr) ? arr : [];
+            if (!Array.isArray(arr)) return [];
+            return arr.map(normalizeRecord);
         } catch {
             return [];
         }
     }
 
     function saveAllNotes(records) {
-        localStorage.setItem(appConfig.storageKey, JSON.stringify(records));
+        const normalized = Array.isArray(records) ? records.map(normalizeRecord) : [];
+        localStorage.setItem(appConfig.storageKey, JSON.stringify(normalized));
     }
 
     // Invariant: never persist empty notes
@@ -32,8 +36,9 @@ export const GravityStore = (() => {
         if ((record.markdownText || "").trim().length === 0) return;
         const all = loadAllNotes();
         const idx = all.findIndex(r => r.noteId === record.noteId);
-        if (idx === -1) all.unshift(record);
-        else all[idx] = record;
+        const sanitizedRecord = normalizeRecord(record);
+        if (idx === -1) all.unshift(sanitizedRecord);
+        else all[idx] = sanitizedRecord;
         saveAllNotes(all);
     }
 
@@ -44,23 +49,31 @@ export const GravityStore = (() => {
     // Sync DOM order to storage (cards only; the top editor is separate)
     function syncFromDom(container) {
         const cards = Array.from(container.querySelectorAll(".markdown-block:not(.top-editor)"));
+        const existingRecords = loadAllNotes();
         const next = [];
         for (const card of cards) {
             const noteId = card.getAttribute("data-note-id");
             const editor = card.querySelector(".markdown-editor");
             const text = editor ? editor.value : "";
             if ((text || "").trim().length === 0) continue; // never create empties
-            const existing = loadAllNotes().find(r => r.noteId === noteId);
+            const existing = existingRecords.find(r => r.noteId === noteId);
             const base = existing ?? {
                 noteId,
                 createdAtIso: nowIso(),
                 updatedAtIso: nowIso(),
                 lastActivityIso: nowIso()
             };
-            next.push({ ...base, markdownText: text });
+            const attachments = collectReferencedAttachments(editor);
+            next.push({ ...base, markdownText: text, attachments });
         }
         saveAllNotes(next);
     }
 
     return { loadAllNotes, saveAllNotes, upsertNonEmpty, removeById, syncFromDom };
 })();
+
+function normalizeRecord(record) {
+    const markdownText = typeof record?.markdownText === "string" ? record.markdownText : "";
+    const attachments = sanitizeAttachmentDictionary(record?.attachments || {});
+    return { ...record, markdownText, attachments };
+}


### PR DESCRIPTION
## Summary
- replace pasted image data URLs with named placeholders while storing the binary data separately per note
- render markdown previews by resolving placeholders to their stored attachments across the top editor, note cards, and merge flows
- persist attachment metadata alongside notes so storage sync keeps image mappings and update the documentation to describe the new UX

## Testing
- python3 -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68d4cfc4636c832792d8d01e8da5146d