### PR TITLE
Enable keyboard navigation between top editor and notes

### DIFF
--- a/ui/navigation.js
+++ b/ui/navigation.js
@@ -1,0 +1,37 @@
+const KEY_ARROW_UP = "ArrowUp";
+const KEY_ARROW_DOWN = "ArrowDown";
+const LINE_BREAK_CHARACTER = "\n";
+
+export function shouldNavigateToPreviousEditor(event, editor) {
+    if (event.key !== KEY_ARROW_UP) return false;
+    if (hasNavigationModifier(event)) return false;
+    if (!isSelectionCollapsed(editor)) return false;
+    return isCaretOnFirstLine(editor);
+}
+
+export function shouldNavigateToNextEditor(event, editor) {
+    if (event.key !== KEY_ARROW_DOWN) return false;
+    if (hasNavigationModifier(event)) return false;
+    if (!isSelectionCollapsed(editor)) return false;
+    return isCaretOnLastLine(editor);
+}
+
+export function hasNavigationModifier(event) {
+    return event.shiftKey || event.altKey || event.ctrlKey || event.metaKey;
+}
+
+export function isSelectionCollapsed(editor) {
+    return editor.selectionStart === editor.selectionEnd;
+}
+
+export function isCaretOnFirstLine(editor) {
+    const caretPosition = editor.selectionStart ?? 0;
+    const textBeforeCaret = editor.value.slice(0, caretPosition);
+    return !textBeforeCaret.includes(LINE_BREAK_CHARACTER);
+}
+
+export function isCaretOnLastLine(editor) {
+    const caretPosition = editor.selectionEnd ?? editor.value.length;
+    const textAfterCaret = editor.value.slice(caretPosition);
+    return !textAfterCaret.includes(LINE_BREAK_CHARACTER);
+}

--- a/ui/topEditor.js
+++ b/ui/topEditor.js
@@ -1,6 +1,7 @@
 import { nowIso, generateNoteId, createElement, autoResize } from "../utils.js";
 import { GravityStore } from "../store.js";
-import { triggerClassificationForCard } from "./card.js";
+import { triggerClassificationForCard, focusCardEditor } from "./card.js";
+import { shouldNavigateToNextEditor } from "./navigation.js";
 import {
     enableClipboardImagePaste,
     waitForPendingImagePastes,
@@ -43,6 +44,13 @@ export function mountTopEditor({ notesContainer, onCreateRecord }) {
         if (ev.key === "Enter" && !ev.shiftKey) {
             ev.preventDefault();
             finalizeTopEditor();
+        }
+
+        if (shouldNavigateToNextEditor(ev, editor)) {
+            const navigated = focusFirstPersistedCard(notesContainer);
+            if (navigated) {
+                ev.preventDefault();
+            }
         }
     });
 
@@ -140,5 +148,11 @@ export function mountTopEditor({ notesContainer, onCreateRecord }) {
 
         // Classify in background and update the new card’s chips
         triggerClassificationForCard(record.noteId, text, notesContainer);
+    }
+
+    function focusFirstPersistedCard(container) {
+        const firstCard = container?.querySelector(".markdown-block:not(.top-editor)");
+        if (!firstCard) return false;
+        return focusCardEditor(firstCard, container, { bubblePreviousCardToTop: false });
     }
 }


### PR DESCRIPTION
## Summary
- share keyboard navigation helpers so cards and the top editor use the same caret detection logic
- allow note cards to focus the top editor when navigating upward from the first note
- enable the top editor to jump into the first persisted card when pressing ArrowDown

## Testing
- manual Playwright scenario verifying ArrowDown from the top editor focuses the first note and ArrowUp returns focus

------
https://chatgpt.com/codex/tasks/task_e_68d57e704cac83279039828a4e3f6366