### PR TITLE
Adjust NoteRecord optional attachments syntax

### DIFF
--- a/store.js
+++ b/store.js
@@ -10,7 +10,7 @@ import { collectReferencedAttachments, sanitizeAttachmentDictionary } from "./ui
  * @property {string} updatedAtIso
  * @property {string} lastActivityIso
  * @property {object=} classification
- * @property {Record<string, { dataUrl: string, altText: string }>=} attachments
+ * @property {Record<string, { dataUrl: string, altText: string }>=} [attachments]
  */
 
 export const GravityStore = (() => {


### PR DESCRIPTION
## Summary
- update the NoteRecord typedef in store.js so the attachments property uses optional JSDoc bracket syntax

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5a4aa985883278b937589da9ce9ab