### PR TITLE
Reset editing state when merging cards

### DIFF
--- a/ui/card.js
+++ b/ui/card.js
@@ -309,6 +309,11 @@ function mergeDown(card, notesContainer) {
 
     const idHere = card.getAttribute("data-note-id");
     GravityStore.removeById(idHere);
+    if (card === currentEditingCard) {
+        card.classList.remove("editing-in-place");
+        delete card.dataset.initialValue;
+        currentEditingCard = null;
+    }
     card.remove();
 
     const idBelow = below.getAttribute("data-note-id");
@@ -353,6 +358,11 @@ function mergeUp(card, notesContainer) {
 
     const idHere = card.getAttribute("data-note-id");
     GravityStore.removeById(idHere);
+    if (card === currentEditingCard) {
+        card.classList.remove("editing-in-place");
+        delete card.dataset.initialValue;
+        currentEditingCard = null;
+    }
     card.remove();
 
     const idAbove = above.getAttribute("data-note-id");


### PR DESCRIPTION
## Summary
- clear in-place editing state if a merged card was currently being edited
- continue existing merge logic after removing the merged card

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5bc300e808327987e58592b3bfd0a