### PR TITLE
Add JSON import/export controls for Gravity Notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,26 +24,30 @@ ones.
   `![[pasted-image-*.png]]` while the rendered preview displays the actual image data.
 * **Auto-Resizing Editor:** The text area automatically adjusts its height to fit the content as you type.
 * **Session-Based:** Notes exist only within the current browser session. Reloading the page will clear all notes.
+* **Import & Export:** Download all saved notes as JSON and import them in another browser without creating duplicates.
 
 ## How to Use
 
 1. **Start Typing:** You begin with a single, empty note at the top in edit mode. Start typing your notes using Markdown
    syntax.
-3. **Create New Note:** When you're done with the current note:
+2. **Create New Note:** When you're done with the current note:
     * Press `Enter` (without holding `Shift`).
     * Or, click outside the editing area (blur the textarea).
     * If the note wasn't empty, it will be finalized (displaying the rendered Markdown), and a new empty note will
       appear above it, ready for editing. If the note was empty, it remains the active note.
-4. **Edit Existing Notes:** Click on the content area of any note below the top one. It will instantly move to the top
+3. **Edit Existing Notes:** Click on the content area of any note below the top one. It will instantly move to the top
    and become the active note in edit mode.
-5. **Move Notes:** Use the `▲` and `▼` buttons on passive notes to change their order relative to other passive notes.
-6. **Merge Notes:**
+4. **Export Notes:** Click **Export** in the header to download a `gravity-notes.json` file containing every saved note.
+5. **Import Notes:** Click **Import** and choose a Gravity Notes JSON export to append non-duplicate notes from another browser.
+   The import ignores records whose `noteId`, Markdown content, attachments, and classification all match an existing note.
+6. **Move Notes:** Use the `▲` and `▼` buttons on passive notes to change their order relative to other passive notes.
+7. **Merge Notes:**
     * To combine a note with the one below it, click the `Merge ↓` button on that note. Its content will be appended to
       the note below it, separated by newlines.
     * To combine the very last note with the currently active (top) note, click the `Merge ↑` button on the last note.
       Its content will be appended to the active note's content, separated by newlines, and the active note will remain
       focused.
-7. **Paste Images:** Copy an image to your clipboard and paste (`Ctrl+V` or `Cmd+V`) directly into the editor textarea.
+8. **Paste Images:** Copy an image to your clipboard and paste (`Ctrl+V` or `Cmd+V`) directly into the editor textarea.
    The image will be inserted as Markdown `![pasted image](data:...)`.
 
 ## Setup

--- a/constants.js
+++ b/constants.js
@@ -1,0 +1,6 @@
+export const LABEL_EXPORT_NOTES = "Export";
+export const LABEL_IMPORT_NOTES = "Import";
+export const FILENAME_EXPORT_NOTES_JSON = "gravity-notes.json";
+export const ACCEPT_IMPORT_NOTES_JSON = "application/json";
+export const ERROR_IMPORT_INVALID_PAYLOAD = "Imported file must contain a JSON array of notes.";
+export const ERROR_IMPORT_READ_FAILED = "Unable to read the selected import file.";

--- a/index.html
+++ b/index.html
@@ -27,6 +27,11 @@
 <header class="app-header">
     <h1 class="app-title">Gravity Notes</h1>
     <div class="app-subtitle">Append anywhere · Bubble to top · Auto-organize</div>
+    <div class="app-controls">
+        <button id="export-notes-button" class="app-control-button" type="button"></button>
+        <button id="import-notes-button" class="app-control-button" type="button"></button>
+        <input id="import-notes-input" type="file" hidden />
+    </div>
 </header>
 
 <!-- Structural, always-empty editor (never persisted) -->

--- a/main.js
+++ b/main.js
@@ -1,11 +1,15 @@
 import { mountTopEditor } from "./ui/topEditor.js";
 import { renderCard, updateActionButtons } from "./ui/card.js";
+import { initializeImportExport } from "./ui/importExport.js";
 import { GravityStore } from "./store.js";
 
 // Markdown options
 marked.setOptions({ gfm: true, breaks: true });
 
 const notesContainer = document.getElementById("notes-container");
+const exportNotesButton = document.getElementById("export-notes-button");
+const importNotesButton = document.getElementById("import-notes-button");
+const importNotesInput = document.getElementById("import-notes-input");
 
 (function boot() {
     // 1) Mount the structural top editor (it will call back into card renderer)
@@ -19,10 +23,24 @@ const notesContainer = document.getElementById("notes-container");
     });
 
     // 2) Load & render persisted notes
-    const records = GravityStore.loadAllNotes();
-    records.sort((a, b) => (b.lastActivityIso || "").localeCompare(a.lastActivityIso || ""));
-    for (const rec of records) {
-        notesContainer.appendChild(renderCard(rec, { notesContainer }));
+    renderPersistedNotes(GravityStore.loadAllNotes());
+
+    initializeImportExport({
+        exportButton: exportNotesButton,
+        importButton: importNotesButton,
+        fileInput: importNotesInput,
+        onRecordsImported: () => {
+            renderPersistedNotes(GravityStore.loadAllNotes());
+        }
+    });
+})();
+
+function renderPersistedNotes(records) {
+    notesContainer.innerHTML = "";
+    const sortedRecords = [...records];
+    sortedRecords.sort((a, b) => (b.lastActivityIso || "").localeCompare(a.lastActivityIso || ""));
+    for (const record of sortedRecords) {
+        notesContainer.appendChild(renderCard(record, { notesContainer }));
     }
     updateActionButtons(notesContainer);
-})();
+}

--- a/styles.css
+++ b/styles.css
@@ -14,6 +14,25 @@ html, body {
 }
 .app-title { margin: 0; font-size: 1.05rem; font-weight: 600; }
 .app-subtitle { margin-top: 0.15rem; font-size: 0.85rem; opacity: 0.7; }
+.app-controls {
+    display: flex;
+    gap: 0.5rem;
+    margin-top: 0.6rem;
+}
+.app-control-button {
+    background: transparent;
+    border: 1px solid #28314a;
+    border-radius: 6px;
+    color: #7aa2ff;
+    cursor: pointer;
+    font-size: 0.85rem;
+    padding: 0.3rem 0.6rem;
+    transition: border-color 0.12s ease, color 0.12s ease, opacity 0.12s ease;
+}
+.app-control-button:hover {
+    color: #b4c8ff;
+    border-color: #3a4b71;
+}
 
 /* Containers */
 .block-container { display: flex; flex-direction: column; }

--- a/ui/importExport.js
+++ b/ui/importExport.js
@@ -1,0 +1,79 @@
+import { LABEL_EXPORT_NOTES, LABEL_IMPORT_NOTES, FILENAME_EXPORT_NOTES_JSON, ACCEPT_IMPORT_NOTES_JSON, ERROR_IMPORT_READ_FAILED } from "../constants.js";
+import { GravityStore } from "../store.js";
+
+const JSON_MIME_TYPE = ACCEPT_IMPORT_NOTES_JSON;
+
+/**
+ * Wire export and import controls to the GravityStore.
+ * @param {{
+ *   exportButton: HTMLButtonElement | null,
+ *   importButton: HTMLButtonElement | null,
+ *   fileInput: HTMLInputElement | null,
+ *   onRecordsImported: (records: import("../store.js").NoteRecord[]) => void
+ * }} options
+ */
+export function initializeImportExport(options) {
+    const { exportButton, importButton, fileInput, onRecordsImported } = options;
+
+    if (exportButton) {
+        exportButton.textContent = LABEL_EXPORT_NOTES;
+        exportButton.addEventListener("click", () => {
+            const payload = GravityStore.exportNotes();
+            triggerJsonDownload(payload);
+        });
+    }
+
+    if (fileInput) {
+        fileInput.accept = ACCEPT_IMPORT_NOTES_JSON;
+        fileInput.addEventListener("change", async () => {
+            const selectedFile = fileInput.files && fileInput.files[0];
+            if (!selectedFile) return;
+            try {
+                const fileContents = await readFileAsText(selectedFile);
+                const appendedRecords = GravityStore.importNotes(fileContents);
+                if (typeof onRecordsImported === "function" && appendedRecords.length > 0) {
+                    onRecordsImported(appendedRecords);
+                }
+            } catch (error) {
+                const errorMessage = error instanceof Error ? error.message : ERROR_IMPORT_READ_FAILED;
+                window.alert(errorMessage);
+            } finally {
+                fileInput.value = "";
+            }
+        });
+    }
+
+    if (importButton && fileInput) {
+        importButton.textContent = LABEL_IMPORT_NOTES;
+        importButton.addEventListener("click", () => {
+            fileInput.click();
+        });
+    }
+}
+
+function triggerJsonDownload(payload) {
+    const blob = new Blob([payload], { type: JSON_MIME_TYPE });
+    const objectUrl = URL.createObjectURL(blob);
+    const anchor = document.createElement("a");
+    anchor.href = objectUrl;
+    anchor.download = FILENAME_EXPORT_NOTES_JSON;
+    document.body.appendChild(anchor);
+    anchor.click();
+    document.body.removeChild(anchor);
+    setTimeout(() => URL.revokeObjectURL(objectUrl), 0);
+}
+
+function readFileAsText(file) {
+    return new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.addEventListener("load", () => {
+            if (typeof reader.result === "string") {
+                resolve(reader.result);
+            } else {
+                reject(new Error(ERROR_IMPORT_READ_FAILED));
+            }
+        });
+        reader.addEventListener("error", () => reject(new Error(ERROR_IMPORT_READ_FAILED)));
+        reader.readAsText(file);
+    });
+}


### PR DESCRIPTION
## Summary
- add GravityStore helpers to export saved notes and import JSON archives with duplicate suppression
- wire new header controls through a dedicated import/export UI module and reuse existing rendering for imported notes
- document the workflow and cover edge cases with table-driven store tests

## Testing
- node --test tests/store.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d6f6efc8cc8327963b33e0fb9211d8