### PR TITLE
Improve header layout responsiveness

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,8 +25,10 @@
 </head>
 <body>
 <header class="app-header">
-    <h1 class="app-title">Gravity Notes</h1>
-    <div class="app-subtitle">Append anywhere · Bubble to top · Auto-organize</div>
+    <div class="app-branding">
+        <h1 class="app-title">Gravity Notes</h1>
+        <div class="app-subtitle">Append anywhere · Bubble to top · Auto-organize</div>
+    </div>
     <div class="app-controls">
         <button id="export-notes-button" class="app-control-button" type="button"></button>
         <button id="import-notes-button" class="app-control-button" type="button"></button>

--- a/styles.css
+++ b/styles.css
@@ -11,13 +11,22 @@ html, body {
     position: sticky; top: 0; z-index: 10;
     background: #0b0c0f; border-bottom: 1px solid #20232b;
     padding: 0.75rem 1rem;
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    column-gap: 1rem;
+    row-gap: 0.75rem;
 }
+.app-branding { display: flex; flex-direction: column; }
 .app-title { margin: 0; font-size: 1.05rem; font-weight: 600; }
 .app-subtitle { margin-top: 0.15rem; font-size: 0.85rem; opacity: 0.7; }
 .app-controls {
     display: flex;
     gap: 0.5rem;
-    margin-top: 0.6rem;
+    flex-wrap: wrap;
+    align-items: center;
+    margin-left: auto;
 }
 .app-control-button {
     background: transparent;
@@ -156,4 +165,14 @@ html, body {
 @media (max-width: 480px) {
     .markdown-block { grid-template-columns: 1fr 5.25rem; }
     .action-button { font-size: 0.85rem; padding: 0.2rem 0.3rem; }
+}
+
+@media (max-width: 640px) {
+    .app-header { align-items: stretch; }
+    .app-controls {
+        margin-left: 0;
+        width: 100%;
+        justify-content: flex-start;
+        row-gap: 0.5rem;
+    }
 }


### PR DESCRIPTION
## Summary
- wrap the header branding elements so the controls can align independently
- update the header styles to use a flexible layout that right-aligns the controls on wide viewports
- add responsive rules to stack and space the controls beneath the title on narrow screens

## Testing
- Manual verification of header layout at desktop and mobile widths


------
https://chatgpt.com/codex/tasks/task_e_68d7192924c083279b4db0b6a60bb8c8